### PR TITLE
support user-name and user-email

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,12 +21,12 @@ func main() {
 		cli.StringFlag{
 			Name:   "commit.author.name",
 			Usage:  "git author name",
-			EnvVar: "DRONE_COMMIT_AUTHOR",
+			EnvVar: "PLUGIN_USER_NAME,DRONE_COMMIT_AUTHOR",
 		},
 		cli.StringFlag{
 			Name:   "commit.author.email",
 			Usage:  "git author email",
-			EnvVar: "DRONE_COMMIT_AUTHOR_EMAIL",
+			EnvVar: "PLUGIN_USER_EMAIL,DRONE_COMMIT_AUTHOR_EMAIL",
 		},
 		cli.StringFlag{
 			Name:   "remote",


### PR DESCRIPTION
option to set github commit author name and email in yaml config

@bradrydzewski and I discussed this change in gitter. let me know if im missing anything and ill get on it.

fixes issue #7 
