### PR TITLE
Expand usage, not only for drone and github

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ docker build \
 
 ## Usage
 
+`PLUGIN_NETRC_MACHINE` is optional, default value is "github.com".
+
 ```console
 docker run --rm \
   -e PLUGIN_USERNAME="octocat" \
   -e PLUGIN_PASSWORD="p455w0rd" \
   -e PLUGIN_PAGES_DIRECTORY="docs" \
+  -e PLUGIN_NETRC_MACHINE="github.com" \
   -e DRONE_COMMIT_AUTHOR="Drone" \
   -e DRONE_COMMIT_AUTHOR_EMAIL="drone@example.com" \
   -e DRONE_REMOTE_URL="https://github.com/drone-plugins/drone-docker.git" \

--- a/main.go
+++ b/main.go
@@ -61,17 +61,17 @@ func main() {
 		cli.StringFlag{
 			Name:   "remote",
 			Usage:  "git remote url",
-			EnvVar: "DRONE_REMOTE_URL",
+			EnvVar: "PLUGIN_REMOTE_URL,DRONE_REMOTE_URL",
 		},
 		cli.StringFlag{
 			Name:   "path",
 			Usage:  "git clone path",
-			EnvVar: "DRONE_WORKSPACE",
+			EnvVar: "PLUGIN_WORKSPACE,DRONE_WORKSPACE",
 		},
 		cli.StringFlag{
 			Name:   "netrc.machine",
 			Usage:  "netrc machine",
-			EnvVar: "DRONE_NETRC_MACHINE",
+			EnvVar: "PLUGIN_NETRC_MACHINE,DRONE_NETRC_MACHINE",
 			Value:  "github.com",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
This plugin could be expanded. Now it's only custom-made for drone and github.com. We can change that without breaking its original functions.