### PR TITLE
Exlcude CNAME, optionally disable delete flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,16 @@ func main() {
 			Usage:  "private ssh key",
 			EnvVar: "PLUGIN_SSH_KEY,GIT_PUSH_SSH_KEY,SSH_KEY",
 		},
+		cli.BoolTFlag{
+			Name:   "exclude-cname",
+			Usage:  "exclude cname file from sync",
+			EnvVar: "PLUGIN_EXCLUDE_CNAME",
+		},
+		cli.BoolTFlag{
+			Name:   "delete",
+			Usage:  "delete files from destination",
+			EnvVar: "PLUGIN_DELETE",
+		},
 		cli.StringFlag{
 			Name:   "commit.author.name",
 			Usage:  "git author name",
@@ -119,6 +129,8 @@ func run(c *cli.Context) error {
 			TargetBranch:   c.String("target-branch"),
 			TemporaryBase:  c.String("temporary-base"),
 			PagesDirectory: c.String("pages-directory"),
+			ExcludeCname:   c.Bool("exclude-cname"),
+			Delete:         c.Bool("delete"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -42,6 +42,8 @@ type (
 		TemporaryBase  string
 		PagesDirectory string
 		WorkDirectory  string
+		ExcludeCname   bool
+		Delete         bool
 	}
 
 	Plugin struct {
@@ -133,16 +135,36 @@ func (p Plugin) cloneTarget() error {
 }
 
 func (p Plugin) rsyncPages() error {
-	cmd := exec.Command(
-		"rsync",
-		"--delete",
+	args := []string{
+		"-r",
 		"--exclude",
 		".git",
-		"--exclude",
-		"CNAME",
-		"-r",
+	}
+
+	if p.Config.ExcludeCname {
+		args = append(
+			args,
+			"--exclude",
+			"CNAME",
+		)
+	}
+
+	if p.Config.Delete {
+		args = append(
+			args,
+			"--delete",
+		)
+	}
+
+	args = append(
+		args,
 		p.Config.PagesDirectory,
 		p.Config.TemporaryBase,
+	)
+
+	cmd := exec.Command(
+		"rsync",
+		args...,
 	)
 
 	cmd.Dir = p.Build.Path


### PR DESCRIPTION
Some people complained that the CNAME file should not be ignored, so I
added a flag to optionally enable the sync of that GitHub specific
config.

Beside that some people also requested to optionally disable the delete
flag of the rsync command executed by this plugin, there is a flag for
that now.

Fixes https://github.com/drone-plugins/drone-gh-pages/issues/23
Fixes https://github.com/drone-plugins/drone-gh-pages/issues/18
