### PR TITLE
Adds PLUGIN_COMMIT_APPEND_TO_MESSAGE which appends to the commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ docker run --rm \
   -w $(pwd) \
   plugins/gh-pages
 ```
+
+`PLUGIN_COMMIT_APPEND_TO_MESSAGE` is also optional, if you want to append something to the commit message generated from the output of `git show -q`.

--- a/main.go
+++ b/main.go
@@ -99,6 +99,12 @@ func main() {
 			Usage:  "netrc password",
 			EnvVar: "PLUGIN_PASSWORD,DRONE_NETRC_PASSWORD,GH_PAGES_PASSWORD,GITHUB_PASSWORD",
 		},
+		cli.StringFlag{
+			Name:   "commit.append_to_message",
+			Usage:  "Something to append to the commit message",
+			EnvVar: "PLUGIN_COMMIT_APPEND_TO_MESSAGE, DRONE_COMMIT_APPEND_TO_MESSAGE",
+			Value:  "",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -121,6 +127,7 @@ func run(c *cli.Context) error {
 				Name:  c.String("commit.author.name"),
 				Email: c.String("commit.author.email"),
 			},
+			AppendToMessage: c.String("commit.append_to_message"),
 		},
 
 		Netrc: Netrc{

--- a/plugin.go
+++ b/plugin.go
@@ -26,7 +26,8 @@ type (
 	}
 
 	Commit struct {
-		Author Author
+		Author          Author
+		AppendToMessage string
 	}
 
 	Netrc struct {
@@ -240,6 +241,7 @@ func (p Plugin) dirtyRepo() bool {
 }
 
 func (p Plugin) commitMessage() ([]byte, error) {
+
 	cmd := exec.Command(
 		"git",
 		"show",
@@ -247,7 +249,13 @@ func (p Plugin) commitMessage() ([]byte, error) {
 	)
 
 	cmd.Dir = p.Build.Path
-	return cmd.Output()
+	output, err := cmd.Output()
+
+	if output != nil && len(output) != 0 && p.Commit.AppendToMessage != "" {
+		output = append(output, []byte(p.Commit.AppendToMessage)...)
+	}
+
+	return output, err
 }
 
 func trace(cmd *exec.Cmd) {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+import "bytes"
+
+func TestCommitAppendToMessage(t *testing.T) {
+	expectedSuffix := "[omg]"
+
+	p := &Plugin{
+		Repo: Repo{
+			Clone: "remote",
+		},
+
+		Build: Build{
+			Path: ".",
+		},
+
+		Commit: Commit{
+			Author: Author{
+				Name:  "commit.author.name",
+				Email: "commit.author.email",
+			},
+			AppendToMessage: expectedSuffix,
+		},
+
+		Netrc: Netrc{
+			Login:    "netrc.username",
+			Machine:  "netrc.machine",
+			Password: "netrc.password",
+		},
+		Config: Config{
+			Key:            "ssh-key",
+			UpstreamName:   "upstream-name",
+			TargetBranch:   "target-branch",
+			TemporaryBase:  "temporary-base",
+			PagesDirectory: "pages-directory",
+			ExcludeCname:   false,
+			Delete:         false,
+			ForcePush:      false,
+		},
+	}
+
+	actual, err := p.commitMessage()
+	if err != nil {
+		t.Errorf("Exec should not error")
+	}
+
+	if !bytes.HasSuffix(actual, []byte(expectedSuffix)) {
+		t.Errorf("Commit message did not end with expected suffix [%s], got: [%s]", expectedSuffix, string(actual))
+	}
+}


### PR DESCRIPTION
I've got a pages build process that is subject to some automated systems and because we have the string "password:" in our documentation, we have to add something to every commit that pushes to any branch in order to disable the scan. This enables us to hardcode the disabling text in our CI configuration.

Also, adds a test because I don't feel confident enough in my Go skills to do anything without tests.

